### PR TITLE
Bumped react-scripts version to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "material-design-icons": "^3.0.1",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
-    "react-scripts": "2.0.0-next.66cc7a90"
+    "react-scripts": "2.1.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
This version bump is required because otherwise `npm run build` is not gonna work any more (will throw error during runtime). New version 2.1.1 of react-scripts has been released few days ago and is considered stable.